### PR TITLE
feat: implement UX improvement plan (phase 1 + phase 2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,36 @@ body {
   margin-top: 1rem;
 }
 
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.step {
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  background: #fff;
+  color: #4b5563;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.82rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.step.active {
+  border-color: #111;
+  color: #111;
+}
+
+.step.done {
+  background: #f3f4f6;
+  color: #111;
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;
@@ -87,19 +117,30 @@ body {
   justify-content: flex-start;
 }
 
+.actionsSticky {
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  padding: 0.5rem 0;
+  z-index: 2;
+}
+
 .presets {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-button {
+button,
+.buttonLike {
   border: 0;
   border-radius: 8px;
   padding: 0.6rem 0.9rem;
   background: #111;
   color: #fff;
   font-weight: 600;
+  text-decoration: none;
+  display: inline-block;
 }
 
 button:disabled {
@@ -125,6 +166,96 @@ small {
   color: #374151;
 }
 
+.queue {
+  display: grid;
+  gap: 0.6rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fff;
+}
+
+.queueList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.queueItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.55rem 0.6rem;
+  background: #fafafa;
+}
+
+.queueMeta {
+  min-width: 0;
+}
+
+.queueName {
+  margin: 0;
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 260px;
+}
+
+.queueState {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.statusPill {
+  border-radius: 999px;
+  padding: 0.2rem 0.45rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: #e5e7eb;
+  color: #111;
+}
+
+.status-processing {
+  background: #111;
+  color: #fff;
+}
+
+.status-done {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.status-error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-cancelled {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.queueDownload {
+  color: #111;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.trust {
+  margin: 0;
+  color: #374151;
+  font-size: 0.85rem;
+}
+
 .result {
   display: grid;
   gap: 0.75rem;
@@ -132,6 +263,21 @@ small {
   border-radius: 10px;
   padding: 0.75rem;
   background: #fafafa;
+}
+
+.outcome {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.savingsBadge {
+  margin: 0;
+  width: fit-content;
+  border-radius: 999px;
+  background: #111;
+  color: #fff;
+  font-weight: 700;
+  padding: 0.3rem 0.65rem;
 }
 
 .stats {
@@ -157,22 +303,6 @@ small {
   max-height: 320px;
   object-fit: contain;
   display: block;
-}
-
-.download {
-  display: inline-block;
-  width: fit-content;
-  text-decoration: none;
-  border-radius: 8px;
-  padding: 0.6rem 0.9rem;
-  background: #111;
-  color: #fff;
-  font-weight: 600;
-}
-
-.download.disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
 }
 
 .bench {
@@ -212,4 +342,22 @@ small {
   margin: 0;
   color: #111;
   font-weight: 600;
+}
+
+@media (min-width: 769px) {
+  .actionsSticky {
+    position: static;
+    padding: 0;
+    background: transparent;
+  }
+}
+
+@media (max-width: 640px) {
+  .queueName {
+    max-width: 170px;
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,10 +8,10 @@ export default function HomePage() {
         <div className="row">
           <h1>WebPify</h1>
           <Link href="/benchmark" className="textLink">
-            Open Benchmark
+            Benchmark (Advanced)
           </Link>
         </div>
-        <p>Phase 4: in-browser conversion with worker cancellation and memory-safe cleanup.</p>
+        <p>Convert images to WebP locally in your browser with fast, private processing.</p>
         <UploadShell />
       </section>
     </main>

--- a/plans/ux-improvement-plan.md
+++ b/plans/ux-improvement-plan.md
@@ -1,0 +1,119 @@
+# UX Improvement Plan (WebPify)
+
+Date: 2026-02-19
+Owner: Product + Frontend
+Status: Proposed
+
+## Goal
+Make the converter feel like a polished product (guided, confidence-building, and outcome-focused) without expanding scope too much.
+
+## Product Problems to Solve
+- The current flow feels like a single utility form instead of a guided experience.
+- The value of conversion is shown, but not emphasized enough visually.
+- First-time users can miss the “what to do next” moment after conversion.
+- Benchmark mode is useful but can distract from the core conversion journey.
+
+## UX Principles
+- Keep first run simple: one clear primary action at each step.
+- Emphasize outcome: saved size and visual quality comparison.
+- Build trust: local processing and privacy-safe messaging.
+- Preserve speed: no heavy interactions or extra navigation overhead.
+
+## Phase 1 — High Impact, Low Risk (MVP+)
+
+### 1) Guided 3-step flow
+**Change**
+- Add lightweight step labels in the main converter card:
+  1. Upload image
+  2. Tune quality
+  3. Download WebP
+
+**Why**
+- Gives structure and reduces “blank form” feeling.
+
+**Acceptance Criteria**
+- Step labels are visible at all times.
+- Active/completed states reflect current progress.
+- No additional page navigation required.
+
+### 2) Before/After outcome emphasis
+**Change**
+- Add a clear before/after section in result area:
+  - Original size
+  - WebP size
+  - Prominent “Saved X%” badge
+
+**Why**
+- Users immediately understand value after conversion.
+
+**Acceptance Criteria**
+- Saved percent is visually prominent and easy to scan.
+- Metrics are shown with consistent formatting.
+- Empty state remains clean before first conversion.
+
+### 3) Single primary CTA behavior
+**Change**
+- Keep one dominant action button:
+  - Before conversion: “Convert to WebP”
+  - After success: “Download WebP”
+
+**Why**
+- Reduces choice paralysis and clarifies the next step.
+
+**Acceptance Criteria**
+- Exactly one primary CTA is visible at a time.
+- Disabled/loading states remain accessible.
+- Download still supports the generated filename.
+
+### 4) Stronger guidance copy + trust line
+**Change**
+- Improve microcopy in empty/error/success states.
+- Add explicit trust statement near upload/output: “Runs locally in your browser. No upload required.”
+
+**Why**
+- Better onboarding and privacy confidence.
+
+**Acceptance Criteria**
+- All key states have concise, friendly text.
+- Trust message is visible without scrolling on desktop.
+
+## Phase 2 — Optional Enhancements
+
+### 5) Batch conversion queue
+- Multi-file upload with per-file progress + per-file download.
+- Keep implementation simple: sequential worker jobs first.
+
+### 6) Intent-based presets
+- Replace/augment low-medium-high with intent labels:
+  - Web (smaller)
+  - Email (balanced)
+  - Max Quality (larger)
+
+### 7) Sticky mobile action row
+- Keep primary action and reset/cancel visible during scroll.
+
+## Information Architecture Recommendation
+- Keep `/` focused on converter (core flow).
+- Keep `/benchmark` but reduce prominence from top-level hero action.
+- Option: place benchmark link as secondary text link under advanced section.
+
+## Delivery Plan
+
+### Sprint 1 (1–2 days)
+- Implement Phase 1 items 1–4.
+- Validate accessibility states (focus, live status, keyboard).
+
+### Sprint 2 (optional, 2–4 days)
+- Implement Phase 2 item 5 (batch queue) first.
+- Add item 6 and 7 if time allows.
+
+## Success Metrics
+- Higher completion rate from file select → download.
+- Lower reset/cancel rate before first successful conversion.
+- Faster time-to-first-successful-download.
+- Positive qualitative feedback: “clearer”, “more polished”, “easy to trust”.
+
+## Out of Scope (for now)
+- Account system, cloud storage, sharing links.
+- Complex editor features (crop/resize/filters).
+- Visual redesign beyond current style system.


### PR DESCRIPTION
## Summary\n- implement guided 3-step conversion flow and stronger trust/status copy\n- add before/after outcome emphasis with prominent savings badge\n- add dynamic primary CTA behavior (convert -> download)\n- add sequential multi-file batch queue with per-file status and download\n- add intent-based quality presets (Web, Email, Max Quality)\n- add sticky mobile action row and queue styling updates\n- add UX implementation plan document under plans\n\n## Validation\n- pnpm lint\n- pnpm build\n\n## Notes\n- benchmark link on home is de-emphasized to advanced wording