### PR TITLE
feat: add batch conversion queue UX and download-all zip

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -189,6 +189,14 @@ body {
   background: transparent;
 }
 
+.queueUtilityActions {
+  gap: 0.4rem;
+}
+
+.queueUtilityActions button {
+  flex: 1;
+}
+
 .presets {
   display: flex;
   gap: 0.5rem;
@@ -262,6 +270,29 @@ small {
   gap: 0.5rem;
 }
 
+.queueFilters {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.queueFilterBtn {
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  color: #334155;
+  border-radius: 999px;
+  padding: 0.24rem 0.6rem;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.queueFilterBtn.active {
+  background: #111;
+  border-color: #111;
+  color: #fff;
+}
+
 .queueItem {
   display: flex;
   align-items: center;
@@ -277,6 +308,11 @@ small {
 .queueItem:hover {
   background: #f8fafc;
   border-color: #cbd5e1;
+}
+
+.queueItem.selected {
+  border-color: #94a3b8;
+  background: #f1f5f9;
 }
 
 .queueMeta {
@@ -296,6 +332,30 @@ small {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.queueActionBtn {
+  border: 0;
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #1f2937;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.queueActionBtn:hover {
+  opacity: 0.7;
+}
+
+.queueEmpty {
+  border: 1px dashed #d1d5db;
+  border-radius: 10px;
+  padding: 0.55rem 0.6rem;
+  background: #fff;
 }
 
 .statusPill {
@@ -363,6 +423,22 @@ small {
   gap: 0.8rem;
   border-bottom: 1px solid hsl(var(--border));
   padding-bottom: 0.45rem;
+}
+
+.batchSummary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.batchSummary span {
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 0.26rem 0.62rem;
+  background: #f8fafc;
+  font-size: 0.78rem;
+  color: #334155;
+  font-weight: 600;
 }
 
 .resultOutput {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.575.0",
     "next": "^15.0.0",
     "react": "^19.0.0",

--- a/plans/batch-conversion-ux-spec.md
+++ b/plans/batch-conversion-ux-spec.md
@@ -1,0 +1,183 @@
+# Batch Conversion UX Spec (WebPify)
+
+Date: 2026-02-19
+Owner: Product + Frontend
+Status: Ready for implementation
+Scope: `/` converter page only (no benchmark changes)
+
+## 1) Intent and Constraints
+
+### User goal
+Convert many images in one session and retrieve outputs with minimal friction.
+
+### UX constraints
+- Keep current two-panel layout and existing design system.
+- Keep a single global quality control for MVP.
+- Do not add new routes or heavy configuration.
+- Preserve privacy trust messaging: local-only processing.
+
+## 2) Information Architecture (MVP)
+
+## Left panel (Control)
+1. Guided steps (existing)
+2. Multi-file dropzone + file summary
+3. Quality slider + presets (existing)
+4. Primary action row (stateful)
+5. Batch status text
+
+## Right panel (Outcome)
+1. Batch summary strip (new)
+2. Latest output stats (existing, keep)
+3. Selected/latest preview compare (existing, keep)
+4. Queue table/list with row actions (existing, enhanced)
+
+Rationale: controls remain on left; decision and outcome clarity move to right where there is space for queue + summary.
+
+## 3) Component-Level Spec
+
+## 3.1 Dropzone
+- Title copy: `Drop images here or click to choose`
+- Helper copy: `PNG, JPEG, and browser-supported image files`
+- Selection summary:
+  - 0 files: `No file selected`
+  - 1 file: `{name} ({size})`
+  - N files: `{N} files ({totalSize})`
+- Validation behavior:
+  - Skip non-image files.
+  - Show non-blocking message: `{X} non-image file(s) were skipped.`
+
+## 3.2 Batch action row
+Use one dominant CTA at a time.
+
+### Idle with queued files
+- Primary: `Convert all`
+- Secondary: `Reset`
+
+### Processing
+- Primary (disabled): `Converting...`
+- Secondary: `Cancel`
+- Optional tertiary text link near queue header: `Clear completed` (disabled while processing)
+
+### Completed (at least one success)
+- Primary: `Download all`
+- Secondary: `Convert new files` (or `Reset` if keeping existing behavior)
+
+## 3.3 Batch summary strip (new)
+Place at top of right panel.
+
+Fields:
+- `Files`: total count
+- `Done`: completed count
+- `Failed`: error count
+- `Cancelled`: cancelled count (only visible if > 0)
+- `Total saved`: sum(inputBytes - outputBytes) for completed items
+- `Avg time`: mean(durationMs) for completed items
+
+Example copy:
+`23 files • 18 done • 2 failed • Saved 34.2 MB • Avg 0.42 s/image`
+
+## 3.4 Queue list enhancements
+Each row shows:
+- File name
+- Input size
+- Status pill: `queued | processing | done | error | cancelled`
+- If done: output size + savings percent
+- Row actions:
+  - Done: `Download`
+  - Error: `Retry`
+  - Queued/cancelled: `Remove`
+
+Queue-level quick filters (tabs/chips):
+- `All`
+- `Processing`
+- `Done`
+- `Failed`
+
+MVP note: filter changes are view-only and do not mutate queue state.
+
+## 3.5 Download strategy
+MVP behavior:
+- If exactly one completed item: preserve existing direct file download.
+- If multiple completed items: `Download all` triggers zipped download (`webpify-exports.zip`).
+- Keep per-row `Download` always available for done items.
+
+## 3.6 Preview behavior
+- Keep existing compare/side-by-side preview.
+- Default preview source: latest completed item.
+- On queue row click, update preview target to that row if it is `done`.
+- If selected row is not `done`, keep current preview and show subtle hint: `Preview available after conversion.`
+
+## 4) State Model (UI + actions)
+
+## States
+- `empty`: no files
+- `ready`: files queued, not converting
+- `processing`: sequential conversion in progress
+- `partial`: processing finished with mixed outcomes
+- `success`: all convertible files done
+- `cancelled`: run cancelled
+
+## Transition rules
+- `empty -> ready`: add valid files
+- `ready -> processing`: click `Convert all`
+- `processing -> cancelled`: click `Cancel`
+- `processing -> success`: all done and no errors
+- `processing -> partial`: at least one done and one error/cancelled
+- `partial/success/cancelled -> ready`: add/remove/retry updates queue to executable state
+- any state -> `empty`: click `Reset` with no kept files
+
+## Action availability matrix
+- `Convert all`: enabled only in `ready`, `partial`, `cancelled` when at least one executable (`queued`/`error`) item exists.
+- `Cancel`: enabled only in `processing`.
+- `Download all`: enabled when completed count >= 1.
+- `Retry failed`: enabled when failed count >= 1 and not processing.
+- `Clear completed`: enabled when completed count >= 1 and not processing.
+
+## 5) Microcopy (final text)
+
+## Global status line
+- Empty: `Select or drop images to start. Processing stays in your browser.`
+- Processing: `Converting {currentName} ({currentIndex}/{total})... keep this tab open.`
+- Success: `Done. Converted {done}/{total} file(s).`
+- Partial: `Completed {done}/{total}. {failed} failed.`
+- Cancelled: `Conversion cancelled. Completed {done}/{total}.`
+
+## Error messages
+- Unsupported file set: `Please select at least one image file.`
+- Per-file fallback: `Failed to convert this image. Try a different file.`
+- Non-image skipped: `{X} non-image file(s) were skipped.`
+
+## Privacy line
+`Runs locally in your browser. No upload required.`
+
+## 6) Accessibility + Interaction Requirements
+- Keep keyboard access for dropzone (`Enter` / `Space`).
+- Status region remains `aria-live="polite"`.
+- Processing state changes must be announced once per item transition (not on every render).
+- Ensure action buttons have deterministic focus order after state transitions.
+- Queue status pills must not rely on color alone (include text labels).
+
+## 7) Instrumentation (privacy-safe, optional)
+Track only aggregate event counts/timings (no file names):
+- `batch_files_added`
+- `batch_convert_started`
+- `batch_convert_completed`
+- `batch_download_all`
+- `batch_retry_failed`
+
+## 8) Implementation Notes for Current Code
+Based on `components/upload-shell.tsx`:
+- Existing queue/status model already supports MVP states.
+- Add derived metrics (`failedCount`, `cancelledCount`, `savedBytesTotal`, `avgDurationMs`).
+- Add queue row actions (`retry`, `remove`, preview select).
+- Add queue filter state (`all|processing|done|failed`).
+- Keep sequential worker processing in MVP; no concurrency required.
+
+## 9) Acceptance Criteria (MVP)
+1. User can select/drop multiple files and convert all in one run.
+2. User sees per-file status and can download each successful output.
+3. User can download all successful outputs through one action.
+4. User can retry only failed files without re-adding successful ones.
+5. User can cancel active processing; remaining queued items move to cancelled/queued per implementation decision.
+6. User always sees privacy-local processing message.
+7. Keyboard and screen-reader status updates remain functional.

--- a/plans/ux-improvement-plan.md
+++ b/plans/ux-improvement-plan.md
@@ -82,6 +82,7 @@ Make the converter feel like a polished product (guided, confidence-building, an
 ### 5) Batch conversion queue
 - Multi-file upload with per-file progress + per-file download.
 - Keep implementation simple: sequential worker jobs first.
+- Detailed implementation spec: `plans/batch-conversion-ux-spec.md`
 
 ### 6) Intent-based presets
 - Replace/augment low-medium-high with intent labels:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.4)
@@ -941,6 +944,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1329,6 +1335,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1336,6 +1345,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1448,6 +1460,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -1486,6 +1501,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1499,6 +1517,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1648,6 +1669,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1735,6 +1759,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1759,6 +1786,9 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -1800,6 +1830,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -1831,6 +1864,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -1893,6 +1929,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2841,6 +2880,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3364,12 +3405,16 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -3493,6 +3538,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -3531,6 +3578,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3545,6 +3599,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -3698,6 +3756,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3765,6 +3825,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  process-nextick-args@2.0.1: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3787,6 +3849,16 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -3845,6 +3917,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -3883,6 +3957,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -4008,6 +4084,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- add batch conversion queue workflow to homepage converter
- add queue filters, per-file retry/remove/download, and batch summary metrics
- add Download all (ZIP) using JSZip with browser-safe download trigger
- move batch queue to outcome panel and align status/microcopy
- add batch UX spec doc and link from UX improvement plan

## Validation
- pnpm lint
- pnpm build

Both commands pass locally.