### PR TITLE
fix: Resolve mobile scrolling issues

### DIFF
--- a/components/upload-shell.tsx
+++ b/components/upload-shell.tsx
@@ -539,7 +539,7 @@ export function UploadShell() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-6 items-start">
       {/* Left Panel: Configuration & Queue */}
-      <div className="flex flex-col gap-6 sticky top-24">
+      <div className="flex flex-col gap-6 lg:sticky lg:top-24">
         <Card className="border-slate-200/60 shadow-sm bg-white/80 backdrop-blur-sm">
           <CardContent className="p-5 flex flex-col gap-6">
             {/* Steps */}
@@ -870,7 +870,7 @@ export function UploadShell() {
                 ) : (
                   <div className="flex flex-col w-full h-full gap-4">
                     <div
-                      className="relative flex-1 rounded-lg overflow-hidden border border-slate-200 bg-white shadow-sm cursor-ew-resize select-none min-h-[300px]"
+                      className="relative flex-1 rounded-lg overflow-hidden border border-slate-200 bg-white shadow-sm cursor-ew-resize select-none min-h-[300px] touch-none"
                       ref={compareCanvasRef}
                       onPointerDown={onComparePointerDown}
                       onPointerMove={onComparePointerMove}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
This PR fixes two mobile scrolling issues:
1. Added `touch-none` to the image comparison slider so dragging it on mobile doesn't accidentally scroll the page.
2. Changed the left configuration panel from `sticky` to `lg:sticky` so it doesn't cause weird scrolling behavior on small screens where it stacks vertically.